### PR TITLE
Bad Interfaces Regexp update

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ The example config contains the following:
 ```
 // config.custom.php
 
-$config['bad_if_regexp'][] = '/^docker[0-9]+$/';
+$config['bad_if_regexp'][] = '/^docker[\w]+$/';
 $config['bad_if_regexp'][] = '/^lxcbr[0-9]+$/';
 $config['bad_if_regexp'][] = '/^veth.*$/';
 $config['bad_if_regexp'][] = '/^virbr.*$/';


### PR DESCRIPTION
Current implementation example, does not match, dynamic docker interfaces like docker78b45b7, etc... created on Synology devices. (Maybe on some others as well, not sure about that)