### PR TITLE
Workaround for rare rrdcached pidfile bug

### DIFF
--- a/files/etc/service/rrdcached/run
+++ b/files/etc/service/rrdcached/run
@@ -1,3 +1,5 @@
 #!/bin/bash -eu
 
+rm -rf /var/run/rrdcached.pid
+
 exec rrdcached -g -w 1800 -z 1800 -f 3600 -s librenms -U librenms -G librenms -B -R -j /var/tmp -l unix:/var/run/rrdcached/rrdcached.sock -t 4 -F -b /opt/librenms/rrd


### PR DESCRIPTION
There are some rare occasions, when rrdcached refuses to remove it's stale pidfile for some reason, left from previous run and fails to start.
We temporarily workaround this issue, by blindly removing it's stale pidfile on service startup, instead of letting rrdcached daemon handle it.