### PR TITLE
Add dnsutils package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN	apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E5267A6C C300EE8C &
 	apt-get -yq autoremove --purge && \
 	apt-get -yq dist-upgrade && \
 	apt-get -yq install --no-install-recommends \
+		dnsutils \
 		nginx \
 		php7.0-cli \
 		php7.0-fpm \


### PR DESCRIPTION
As Nagios DNS plugin requires nslookup to operate, we should include dnsutils package in our image.